### PR TITLE
Update run-multiple.js

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -14,7 +14,7 @@ const clearString = require('../utils').clearString;
 const runner = path.join(__dirname, '/../../bin/codecept');
 let config;
 const childOpts = {};
-const copyOptions = ['steps', 'reporter', 'verbose', 'config', 'reporter-options', 'grep', 'fgrep', 'debug'];
+const copyOptions = ['override', 'steps', 'reporter', 'verbose', 'config', 'reporter-options', 'grep', 'fgrep', 'debug'];
 
 // codeceptjs run:multiple smoke:chrome regression:firefox - will launch smoke run in chrome and regression in firefox
 // codeceptjs run:multiple smoke:chrome regression - will launch smoke run in chrome and regression in firefox and chrome


### PR DESCRIPTION
Allow configuration override CLI flag when running multiple tests in parallel.